### PR TITLE
Fix daterange yielding str instead of datetime at end boundary

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -14,10 +14,10 @@ def daterange(start_date : str, end_date : str, step : int=1):
     
     for n in range(0, int((end_dt - start_dt).days), step):
         dt = start_dt + timedelta(n)
-        if dt == end_date:
+        if dt == end_dt:
             seen_end_dt = True
         yield dt
     
     if not seen_end_dt:
-        yield end_date
+        yield end_dt
     


### PR DESCRIPTION
## Summary
- `daterange()` was yielding `end_date` (a `str`) as the final value instead of `end_dt` (a `datetime`), causing `'str' object has no attribute 'strftime'` crash in the `/performance` endpoint
- The `dt == end_date` comparison (datetime vs str) was always `False`, meaning the end date was always appended as a duplicate entry

## Test plan
- [ ] Load the performance chart in the UI — should no longer show "Failed to load performance data"
- [ ] Verify the date range in the chart doesn't include a duplicate end date

🤖 Generated with [Claude Code](https://claude.com/claude-code)