### PR TITLE
Pre-fetch and cache benchmark prices in DB

### DIFF
--- a/backend/benchmark_fetcher.py
+++ b/backend/benchmark_fetcher.py
@@ -1,0 +1,108 @@
+"""
+Fetches and caches benchmark index prices in the BENCHMARK_PRICES table.
+
+Runs as part of the background data fetch on startup so that benchmark
+comparison and risk metric endpoints read from the DB rather than calling
+Yahoo Finance on every request.
+"""
+
+import time
+import pandas as pd
+import yfinance as yf
+from utils import utils
+from datetime import datetime
+from . import base
+
+# Tickers shown in the BenchmarkChart UI selector
+BENCHMARK_TICKERS = ['SPY', 'QQQ', 'IWM', 'EFA', 'GLD', 'AGG']
+
+_CREATE_TABLE_SQL = '''
+    CREATE TABLE IF NOT EXISTS BENCHMARK_PRICES (
+        TICKER TEXT NOT NULL,
+        DATE   TEXT NOT NULL,
+        CLOSE  REAL,
+        PRIMARY KEY (TICKER, DATE)
+    )
+'''
+
+
+class BenchmarkFetcher:
+    def __init__(self, db_conn: base.BaseDBConnector):
+        self.db_conn = db_conn
+        self._ensure_table()
+
+    def _ensure_table(self):
+        self.db_conn._conn.execute(_CREATE_TABLE_SQL)
+        self.db_conn._conn.commit()
+
+    def _last_stored_date(self, ticker: str):
+        """Return the latest DATE we have for this ticker, or None."""
+        try:
+            df = self.db_conn.read_query(
+                f"SELECT MAX(DATE) as D FROM BENCHMARK_PRICES WHERE TICKER = '{ticker}'"
+            )
+            val = df['D'].iloc[0]
+            return val if val else None
+        except Exception:
+            return None
+
+    def fetch_missing(self, start_date: str, end_date: str):
+        """Fetch and store any missing benchmark price data."""
+        for ticker in BENCHMARK_TICKERS:
+            last = self._last_stored_date(ticker)
+            fetch_from = last if last and last > start_date else start_date
+
+            if fetch_from >= end_date:
+                continue
+
+            try:
+                time.sleep(0.1)
+                t = yf.Ticker(ticker)
+                hist = t.history(start=fetch_from, end=end_date)
+                if hist.empty:
+                    continue
+
+                hist = hist[['Close']].reset_index()
+                # Strip timezone from Date if present
+                if hasattr(hist['Date'].dtype, 'tz') and hist['Date'].dtype.tz is not None:
+                    hist['Date'] = hist['Date'].dt.tz_localize(None)
+                hist['DATE'] = hist['Date'].apply(lambda x: x.strftime('%Y-%m-%d'))
+                hist['TICKER'] = ticker
+                hist['CLOSE'] = hist['Close']
+
+                for _, row in hist[['TICKER', 'DATE', 'CLOSE']].iterrows():
+                    self.db_conn._conn.execute(
+                        'INSERT OR IGNORE INTO BENCHMARK_PRICES (TICKER, DATE, CLOSE) VALUES (?, ?, ?)',
+                        (row['TICKER'], row['DATE'], float(row['CLOSE']))
+                    )
+                self.db_conn._conn.commit()
+                print(f'Stored {len(hist)} rows for benchmark {ticker}')
+            except Exception as e:
+                print(f'Failed to fetch benchmark {ticker}: {e}')
+
+
+def get_benchmark_prices_from_db(db_conn: base.BaseDBConnector,
+                                  ticker: str,
+                                  start_date: str,
+                                  end_date: str) -> pd.DataFrame:
+    """
+    Read benchmark close prices from the DB for the given date range.
+    Returns a DataFrame with a datetime index and a 'price' column.
+    Returns an empty DataFrame if no data is found.
+    """
+    try:
+        df = db_conn.read_query(f'''
+            SELECT DATE, CLOSE as price
+            FROM BENCHMARK_PRICES
+            WHERE TICKER = '{ticker}'
+              AND DATE >= '{start_date}'
+              AND DATE <= '{end_date}'
+            ORDER BY DATE
+        ''')
+        if df.empty:
+            return pd.DataFrame()
+        df['date'] = pd.to_datetime(df['DATE'])
+        df = df.set_index('date')[['price']]
+        return df
+    except Exception:
+        return pd.DataFrame()

--- a/backend/benchmarks.py
+++ b/backend/benchmarks.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 from . import base, misc_fetcher, ticker_fetcher, fx_fetcher
 from .api import PortfolioStats
+from .benchmark_fetcher import get_benchmark_prices_from_db
 from utils import utils
 
 # Annualized risk-free rate (approximate 10Y government bond yield)
@@ -69,15 +70,21 @@ class PortfolioBenchmark:
         return df
 
     def _get_benchmark_prices(self, benchmark_ticker):
-        """Fetch benchmark prices from Yahoo Finance for the date range."""
+        """Return benchmark close prices, preferring the local DB cache."""
+        df = get_benchmark_prices_from_db(
+            self.db_conn, benchmark_ticker, self.start_date, self.end_date
+        )
+        if not df.empty:
+            return df
+        # Fall back to live Yahoo Finance if DB has no data
         try:
             ticker = base.yf.Ticker(benchmark_ticker)
-            df = ticker.history(start=self.start_date, end=self.end_date)
-            if df.empty:
+            hist = ticker.history(start=self.start_date, end=self.end_date)
+            if hist.empty:
                 return pd.DataFrame()
-            df = df[['Close']].rename(columns={'Close': 'price'})
-            df.index = df.index.tz_localize(None)
-            return df
+            hist = hist[['Close']].rename(columns={'Close': 'price'})
+            hist.index = hist.index.tz_localize(None)
+            return hist
         except Exception:
             return pd.DataFrame()
 
@@ -287,12 +294,18 @@ class RiskMetrics:
             return None
 
         try:
-            bench = base.yf.Ticker(benchmark_ticker)
-            bench_df = bench.history(start=self.start_date, end=self.end_date)
+            bench_df = get_benchmark_prices_from_db(
+                self.db_conn, benchmark_ticker, self.start_date, self.end_date
+            )
             if bench_df.empty:
-                return None
-            bench_df.index = bench_df.index.tz_localize(None)
-            bench_returns = bench_df['Close'].resample(f'{self.step}D').last().pct_change().dropna()
+                # Fall back to live YF
+                bench = base.yf.Ticker(benchmark_ticker)
+                raw = bench.history(start=self.start_date, end=self.end_date)
+                if raw.empty:
+                    return None
+                raw.index = raw.index.tz_localize(None)
+                bench_df = raw[['Close']].rename(columns={'Close': 'price'})
+            bench_returns = bench_df['price'].resample(f'{self.step}D').last().pct_change().dropna()
         except Exception:
             return None
 
@@ -327,10 +340,17 @@ class RiskMetrics:
             return None
 
         try:
-            bench = base.yf.Ticker(benchmark_ticker)
-            bench_df = bench.history(start=self.start_date, end=self.end_date)
-            bench_df.index = bench_df.index.tz_localize(None)
-            bench_returns = bench_df['Close'].pct_change().dropna()
+            bench_df = get_benchmark_prices_from_db(
+                self.db_conn, benchmark_ticker, self.start_date, self.end_date
+            )
+            if bench_df.empty:
+                bench = base.yf.Ticker(benchmark_ticker)
+                raw = bench.history(start=self.start_date, end=self.end_date)
+                if raw.empty:
+                    return None
+                raw.index = raw.index.tz_localize(None)
+                bench_df = raw[['Close']].rename(columns={'Close': 'price'})
+            bench_returns = bench_df['price'].pct_change().dropna()
         except Exception:
             return None
 

--- a/server.py
+++ b/server.py
@@ -7,6 +7,7 @@ from flask_cors import CORS
 
 import multiprocessing
 from backend import fx_fetcher, misc_fetcher, ticker_fetcher, base, api, benchmarks
+from backend.benchmark_fetcher import BenchmarkFetcher
 from utils import utils
 
 import pandas as pd
@@ -27,8 +28,11 @@ def fetch_data():
         fx_fetcher_ = fx_fetcher.FxFetcher(db_conn)
         misc_fetcher_ = misc_fetcher.MiscFetcher(db_conn)
 
-        ticker_fetcher_.fetch_ticker_hist(misc_fetcher_.fetch_fst_trans(), utils.date2str(datetime.now()))
-        fx_fetcher_.fetch_missing_fx(misc_fetcher_.fetch_fst_trans(), utils.date2str(datetime.now()))
+        start_dt = misc_fetcher_.fetch_fst_trans()
+        end_dt = utils.date2str(datetime.now())
+        ticker_fetcher_.fetch_ticker_hist(start_dt, end_dt)
+        fx_fetcher_.fetch_missing_fx(start_dt, end_dt)
+        BenchmarkFetcher(db_conn).fetch_missing(start_dt, end_dt)
         logger.info("Background data fetch completed successfully")
     except Exception as e:
         logger.error(f"Background data fetch failed: {e}")


### PR DESCRIPTION
## Summary
- Adds `BenchmarkFetcher` that stores SPY, QQQ, IWM, EFA, GLD, AGG closing prices in a `BENCHMARK_PRICES` SQLite table during the background fetch on startup
- `PortfolioBenchmark._get_benchmark_prices`, `RiskMetrics.beta`, and `RiskMetrics.alpha` now use the cached DB data first, with live Yahoo Finance as a fallback
- Wired into `fetch_data()` in `server.py` alongside the existing ticker/FX fetchers

## Why
Benchmark endpoints previously called Yahoo Finance live on every request, making the benchmark chart slow and unreliable. Now data is pre-fetched once on startup and kept up to date incrementally.

## Test plan
- [ ] On startup, logs show benchmark rows being stored for SPY/QQQ/etc
- [ ] `/benchmark?benchmark=SPY` returns chart data without live YF call
- [ ] `/risk_metrics` returns non-null beta/alpha values

🤖 Generated with [Claude Code](https://claude.com/claude-code)