### PR TITLE
Add .dockerignore to ensure core.db is never baked into images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Never bake the live database into the image.
+# core.db is bind-mounted at runtime via docker-compose volumes.
+core.db
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+
+# Dev / test artefacts
+test.ipynb
+.ipynb_checkpoints/
+*.egg-info/
+dist/
+build/
+
+# Editor / OS
+.env
+.venv
+.git
+.gitignore
+*.code-workspace


### PR DESCRIPTION
## Summary
- Adds `.dockerignore` excluding `core.db` (and common Python/dev noise) from the Docker build context
- Without this, `COPY . .` silently bakes a stale database snapshot into every image; if the bind-mount is ever missing or misconfigured the container uses that stale copy and all data changes since the last build are lost
- With this in place the container **must** use the volume-mounted `core.db`, making persistence explicit and reliable

## Also changed (outside git — docker-compose.dev.yml)
- Removed the redundant `./StockPortfolioManager/core.db:/app/core.db` mount from `docker-compose.dev.yml`; the directory-level mount `./StockPortfolioManager:/app` already covers it and having both caused conflicts on Windows Docker Desktop

## Test plan
- [ ] `docker-compose up --build` — confirm container starts and uses existing `core.db`
- [ ] Add a transaction, restart container (`docker-compose restart`) — confirm transaction persists
- [ ] Rebuild image (`docker-compose up --build`) — confirm data still persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)