### PR TITLE
Fix period profit ticker scoping and add Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose port
+EXPOSE 5001
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:5001/health')" || exit 1
+
+# Use gunicorn in production with preloading for the data fetch
+CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--workers", "2", "--timeout", "120", "server:app"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose port
+EXPOSE 5001
+
+# Run with auto-reload for development
+ENV FLASK_ENV=development
+CMD ["python", "server.py"]

--- a/backend/api.py
+++ b/backend/api.py
@@ -182,18 +182,30 @@ class Fee(Metric):
         return np.round(PortfolioStats(self.db_path, self.ref_dt).get_fee()) 
 
 class PeriodProfitVal(Metric):
-    def __init__(self, db_path, period, ref_dt=None) -> None:
+    def __init__(self, db_path, period, filters=None, filter_kind=None, ref_dt=None) -> None:
         super().__init__('periodprofitval', db_path, period, ref_dt)
+        self.filters = filters
+        self.filter_kind = filter_kind
 
     def compute(self):
         start_dt = utils.str2date(self.ref_dt) - self.period.delta
+
+        if self.filters and self.filter_kind:
+            db_conn = base.BaseDBConnector(self.db_path)
+            fetcher = misc_fetcher.MiscFetcher(db_conn=db_conn)
+
+            start_dt_filter = fetcher.fetch_fst_trans_on_filter(self.filters, self.filter_kind)
+            start_dt_filter = utils.str2date(start_dt_filter)
+            if start_dt_filter > start_dt:
+                start_dt = start_dt_filter
+
         start_dt = utils.date2str(start_dt)
 
-        start_profit = PortfolioStats(self.db_path, start_dt).get_profit()
-        end_profit = PortfolioStats(self.db_path, self.ref_dt).get_profit()
+        start_profit = PortfolioStats(self.db_path, start_dt, self.filters, self.filter_kind).get_profit()
+        end_profit = PortfolioStats(self.db_path, self.ref_dt, self.filters, self.filter_kind).get_profit()
 
         profit = end_profit - start_profit
-        n_days = self.period.delta.total_seconds() / ( 3600 * 24)
+        n_days = (utils.str2date(self.ref_dt) - utils.str2date(start_dt)).total_seconds() / (3600 * 24)
 
         annualized_profit = profit * 365 / n_days
 

--- a/server.py
+++ b/server.py
@@ -343,7 +343,7 @@ def metric():
         elif metric_ == 'fee':
             metric_val = api.Fee(DB_PATH, period_).compute()
         elif metric_ == 'annualized_profit_period':
-            metric_val = api.PeriodProfitVal(DB_PATH, period_).compute()
+            metric_val = api.PeriodProfitVal(DB_PATH, period_, ticker, filter_kind).compute()
         elif metric_ == 'annualized_profit_perc_period':
             metric_val = api.PeriodProfitPerc(DB_PATH, period_, ticker, filter_kind).compute()
         elif metric_ == 'PE':


### PR DESCRIPTION
## Summary
- fix annualized period profit metric to honor ticker/filter scope
- pass ticker and filter kind through /metric for annualized_profit_period
- add production and development Dockerfiles

## Details
- updated PeriodProfitVal to accept filters and filter_kind
- applied filtered PortfolioStats at start and end of period for consistent scoped computation
- aligned start date handling with first transaction date for selected filter scope
- staged and committed only backend/api.py, server.py, Dockerfile, Dockerfile.dev

## Validation
- rebuilt containers successfully with docker compose from workspace root
