### PR TITLE
Harden misc fetcher queries against SQL injection

### DIFF
--- a/backend/base.py
+++ b/backend/base.py
@@ -37,8 +37,8 @@ class BaseDBConnector:
 
         return pd.read_sql(query, self._conn)
     
-    def read_query(self, query):
-        return pd.read_sql(query, self._conn)
+    def read_query(self, query, params=None):
+        return pd.read_sql(query, self._conn, params=params)
 
 class TableHandler:
     def __init__(self, db_connector, table_name, pk) -> None:
@@ -82,5 +82,5 @@ class DataFetcher:
     def __init__(self, db_conn: BaseDBConnector):
         self.db_conn = db_conn
 
-    def fetch_query(self, query):
-        return  self.db_conn.read_query(query)
+    def fetch_query(self, query, params=None):
+        return self.db_conn.read_query(query, params=params)

--- a/backend/misc_fetcher.py
+++ b/backend/misc_fetcher.py
@@ -6,17 +6,41 @@ from .sql import queries
 from .api import PortfolioStats
 from utils import utils
 
+
+ALLOWED_FILTER_KINDS = {'TICKER', 'COUNTRY', 'SECTOR', 'FX', 'MARKET', 'SRC'}
+
 class MiscFetcher(DataFetcher):
     
     def __init__(self, db_conn):
         super().__init__(db_conn)
 
+    def _validate_filter_kind(self, filter_kind):
+        if filter_kind not in ALLOWED_FILTER_KINDS:
+            raise ValueError(f'Invalid filter_kind: {filter_kind}')
+        return filter_kind
+
     def fetch_security_src(self, ticker):
-        res_ = self.fetch_query(queries.SECURITY_DATA_SOURCE.format(ticker)).values[0][0]
+        query = '''
+            SELECT SRC
+            FROM `SECURITY`
+            WHERE TICKER = ?
+        '''
+        res_ = self.fetch_query(query, params=(ticker,)).values[0][0]
         return res_
     
     def fetch_fst_trans_on_filter(self, filter, filter_kind):
-        res_ = self.fetch_query(queries.FST_TRANS_ON_FILTER.format(filter=filter, filter_kind=filter_kind))['DATE'][0]
+        filter_kind = self._validate_filter_kind(filter_kind)
+        query = f'''
+            SELECT
+                MIN(DATE(trans.DATE)) as DATE
+            FROM
+                `TRANSACTION` trans
+            INNER JOIN
+                `SECURITY` sec ON trans.TICKER = sec.TICKER
+            WHERE
+                sec.{filter_kind} = ?
+        '''
+        res_ = self.fetch_query(query, params=(filter,))['DATE'][0]
         return res_
 
     def fetch_security_equity_gain_amt(self, ticker, ref_dt):
@@ -29,41 +53,124 @@ class MiscFetcher(DataFetcher):
         return res_
 
     def fetch_security_cost_basis_amt(self, ticker):
-        res_ = self.fetch_query(queries.SECURITY_COST_BASIS_VAL.format(ticker))
+        query = '''
+            SELECT
+                SUM(AMOUNT * PRICE * FX) + SUM(FEE * FX)
+            FROM
+                `TRANSACTION`
+            WHERE TICKER = ?
+        '''
+        res_ = self.fetch_query(query, params=(ticker,))
         return res_
 
     def fetch_security_dividend_amt(self, ticker):
-        res_ = self.fetch_query(queries.SECURITY_DIV_VAL.format(ticker))
+        query = '''
+            SELECT
+                SUM(AMOUNT * FX)
+            FROM
+                `DIVIDEND`
+            WHERE TICKER = ?
+        '''
+        res_ = self.fetch_query(query, params=(ticker,))
         return res_
 
     def fetch_fst_trans(self):
         return self.fetch_query(queries.FST_TICKER_TRANS_QUERY).FST_BUY_DT[0]
 
     def fetch_portfolio_composition(self, portfolio_id : int, ref_date : str):
-        return self.fetch_query(queries.PORTFOLIO_COMP_QUERY.format(ref_date, ref_date))
+        query = '''
+            SELECT
+                t1.TICKER,
+                t2.SECTOR,
+                t2.COUNTRY,
+                t2.FX,
+                SUM(t1.FEE * t1.FX) as TOTAL_FEE,
+                SUM(t1.AMOUNT) as N_SHARES,
+                SUM(t1.AMOUNT * t1.PRICE * t1.FX) as TOTAL_COST,
+                ? as DT
+            FROM
+                'TRANSACTION' as t1
+            INNER JOIN
+                'SECURITY' as t2
+            ON
+                t1.TICKER = t2.TICKER
+            WHERE
+                1 = 1
+                AND DATE(t1.DATE) <= DATE(?)
+            GROUP BY
+                t1.TICKER
+        '''
+        return self.fetch_query(query, params=(ref_date, ref_date))
 
     def fetch_fst_trans_on_ticker(self, ticker, cnt):
-        res_ = self.fetch_query(queries.FST_TRANS_TICKER.format(ticker, cnt)).iloc[0]
+        cnt = int(cnt)
+        query = '''
+            SELECT 
+                TICKER,
+                DATE,
+                AMOUNT as N_SHARES
+            FROM `TRANSACTION`
+            WHERE TICKER = ?
+            ORDER BY DATE ASC
+            LIMIT ?
+        '''
+        res_ = self.fetch_query(query, params=(ticker, cnt)).iloc[0]
         return res_
     
     def fetch_last_trans_on_ticker(self, ticker, cnt):
-        res_ = self.fetch_query(queries.F.format(ticker, cnt))
+        cnt = int(cnt)
+        query = '''
+            SELECT 
+                TICKER,
+                DATE,
+                AMOUNT as N_SHARES
+            FROM `TRANSACTION`
+            WHERE TICKER = ?
+            ORDER BY DATE DESC
+            LIMIT ?
+        '''
+        res_ = self.fetch_query(query, params=(ticker, cnt))
         return res_
     
     def fetch_last_div_on_ticker(self, ticker, cnt):
-        res_ = self.fetch_query(queries.LAST_DIVIDEND_TICKER.format(ticker, cnt))
+        cnt = int(cnt)
+        query = '''
+            SELECT 
+                TICKER,
+                DATE,
+                AMOUNT as AMT
+            FROM `DIVIDEND`
+            WHERE TICKER = ?
+            ORDER BY DATE DESC
+            LIMIT ?
+        '''
+        res_ = self.fetch_query(query, params=(ticker, cnt))
         return res_
     
     def fetch_dividend_amt(self, start_dt, end_dt):
-        print(queries.DIVIDEND_AMT_QUERY.format(start_dt, end_dt))
-        res_ = self.fetch_query(queries.DIVIDEND_AMT_QUERY.format(start_dt, end_dt))
+        query = '''
+            SELECT
+                div.AMOUNT * div.FX as AMT,
+                div.DATE,
+                sec.*
+            FROM
+                `DIVIDEND` div
+            INNER JOIN
+                `SECURITY` sec ON div.TICKER = sec.TICKER
+            WHERE
+                1 = 1
+                AND DATE(div.DATE) >= DATE(?) AND DATE(div.DATE) <= DATE(?)
+        '''
+        res_ = self.fetch_query(query, params=(start_dt, end_dt))
         return res_
 
     def fetch_activity(self, ticker, filter_kind='TICKER'):
+        filter_kind = self._validate_filter_kind(filter_kind)
+        params = None
         if ticker == 'ALL':
             where_condition = '1 = 1'
         else:
-            where_condition = f"{filter_kind} = '{ticker}'"
-        print(queries.ACTIVITY_QUERY.format(where_condition))
-        res_ = self.fetch_query(queries.ACTIVITY_QUERY.format(where_condition))
+            where_condition = f'{filter_kind} = ?'
+            params = (ticker,)
+        res_ = self.fetch_query(queries.ACTIVITY_QUERY.format(where_condition), params=params)
         return res_


### PR DESCRIPTION
## Summary
- add parameterized query support in BaseDBConnector/DataFetcher
- replace vulnerable string-formatted queries in MiscFetcher with parameterized SQL
- enforce allowlist validation for filter_kind in activity/filter endpoints

## Why
Several fetcher paths interpolated request values directly into SQL. This PR reduces injection exposure while preserving existing API behavior.

## Notes
- keeps dynamic column interpolation only after strict allowlist validation
- stages only backend/base.py and backend/misc_fetcher.py
