### PR TITLE
Add available_filters API for dynamic frontend selectors

### DIFF
--- a/backend/misc_fetcher.py
+++ b/backend/misc_fetcher.py
@@ -67,3 +67,46 @@ class MiscFetcher(DataFetcher):
         print(queries.ACTIVITY_QUERY.format(where_condition))
         res_ = self.fetch_query(queries.ACTIVITY_QUERY.format(where_condition))
         return res_
+
+    def fetch_security_universe(self):
+        query = '''
+            SELECT
+                TICKER,
+                COUNTRY,
+                SECTOR,
+                FX,
+                MARKET,
+                SRC
+            FROM
+                `SECURITY`
+        '''
+        return self.fetch_query(query)
+
+    def fetch_available_filters(self, ref_date=None, active_only=True):
+        if active_only:
+            if ref_date is None:
+                ref_date = utils.date2str(utils.datetime.now())
+            df_universe = self.fetch_portfolio_composition(1, ref_date=ref_date)
+            if 'N_SHARES' in df_universe.columns:
+                df_universe = df_universe[df_universe['N_SHARES'] > 0]
+        else:
+            df_universe = self.fetch_security_universe()
+
+        filter_kinds = ['TICKER', 'COUNTRY', 'SECTOR', 'FX', 'MARKET', 'SRC']
+        filters = {}
+        counts = {}
+
+        for kind in filter_kinds:
+            if kind in df_universe.columns:
+                vals = sorted([x for x in df_universe[kind].dropna().unique().tolist() if str(x) != ''])
+            else:
+                vals = []
+            filters[kind] = vals
+            counts[kind] = len(vals)
+
+        return {
+            'as_of': ref_date,
+            'active_only': active_only,
+            'filters': filters,
+            'counts': counts,
+        }

--- a/server.py
+++ b/server.py
@@ -316,6 +316,21 @@ def activity():
         logger.error(f"Activity error: {e}")
         return jsonify({"error": str(e)}), 500
 
+
+@app.route('/available_filters', methods=['GET'])
+def available_filters():
+    """List available filter values for TICKER/COUNTRY/SECTOR/FX/MARKET/SRC."""
+    try:
+        ref_date = request.args.get('ref_date', utils.date2str(datetime.now()))
+        active_only = request.args.get('active_only', 'true').lower() in ('1', 'true', 'yes')
+
+        db_conn = base.BaseDBConnector(DB_PATH)
+        misc_fetcher_ = misc_fetcher.MiscFetcher(db_conn)
+        return misc_fetcher_.fetch_available_filters(ref_date=ref_date, active_only=active_only)
+    except Exception as e:
+        logger.error(f"Available filters error: {e}")
+        return jsonify({"error": str(e)}), 500
+
 @app.route("/metric", methods=['GET'])
 def metric():
     try:


### PR DESCRIPTION
## Summary
- add GET /available_filters endpoint
- support ef_date and ctive_only query params
- return normalized filter value lists and per-filter counts

## Response shape
- s_of: date used for the calculation
- ctive_only: whether data is restricted to active holdings
- ilters: values for TICKER, COUNTRY, SECTOR, FX, MARKET, SRC
- counts: cardinality for each filter kind

## Why
This enables the UI to build dynamic filter dropdowns/chips without hardcoded values.
