### PR TITLE
Add scoped and interval-aware benchmark_multi API

### DIFF
--- a/backend/inflation_fetcher.py
+++ b/backend/inflation_fetcher.py
@@ -6,7 +6,6 @@ Normalization rule:
 """
 
 from datetime import datetime
-from io import StringIO
 from typing import Optional
 
 import pandas as pd
@@ -14,8 +13,7 @@ import requests
 
 from . import base
 
-ROMANIA_CPI_SERIES = 'ROUCPIALLMINMEI'
-FRED_CSV_URL = 'https://fred.stlouisfed.org/graph/fredgraph.csv?id={series_id}'
+WORLD_BANK_CPI_URL = 'https://api.worldbank.org/v2/country/ROU/indicator/FP.CPI.TOTL?format=json&per_page=20000'
 
 _CREATE_TABLE_SQL = '''
     CREATE TABLE IF NOT EXISTS ROMANIA_CPI (
@@ -46,23 +44,29 @@ class InflationFetcher:
             return None
 
     def _fetch_romania_cpi(self):
-        url = FRED_CSV_URL.format(series_id=ROMANIA_CPI_SERIES)
-        resp = requests.get(url, timeout=30)
+        resp = requests.get(WORLD_BANK_CPI_URL, timeout=30)
         resp.raise_for_status()
 
-        df = pd.read_csv(StringIO(resp.text))
-        # Expected columns: DATE, ROUCPIALLMINMEI
-        if 'DATE' not in df.columns or ROMANIA_CPI_SERIES not in df.columns:
+        payload = resp.json()
+        if not isinstance(payload, list) or len(payload) < 2:
             return pd.DataFrame(columns=['DATE', 'CPI'])
 
-        df = df[['DATE', ROMANIA_CPI_SERIES]].copy()
-        df.rename(columns={ROMANIA_CPI_SERIES: 'CPI'}, inplace=True)
+        obs = payload[1]
+        if not isinstance(obs, list):
+            return pd.DataFrame(columns=['DATE', 'CPI'])
 
-        df['DATE'] = pd.to_datetime(df['DATE'], errors='coerce')
+        df = pd.DataFrame(obs)
+        if 'date' not in df.columns or 'value' not in df.columns:
+            return pd.DataFrame(columns=['DATE', 'CPI'])
+
+        # World Bank CPI is annual; represent each value at year-end so it can be aligned on chart dates.
+        df = df[['date', 'value']].copy()
+        df.rename(columns={'date': 'YEAR', 'value': 'CPI'}, inplace=True)
+        df['DATE'] = pd.to_datetime(df['YEAR'].astype(str) + '-12-31', errors='coerce')
         df['CPI'] = pd.to_numeric(df['CPI'], errors='coerce')
         df = df.dropna(subset=['DATE', 'CPI'])
         df = df.sort_values('DATE').reset_index(drop=True)
-        return df
+        return df[['DATE', 'CPI']]
 
     def fetch_and_store(self, end_date: Optional[str] = None):
         base_date = self._oldest_transaction_date()

--- a/backend/inflation_fetcher.py
+++ b/backend/inflation_fetcher.py
@@ -1,0 +1,130 @@
+"""
+Fetches Romania CPI time series and stores it in ROMANIA_CPI.
+
+Normalization rule:
+- CPI100 is rebased so that CPI = 100 at the portfolio oldest transaction date.
+"""
+
+from datetime import datetime
+from io import StringIO
+from typing import Optional
+
+import pandas as pd
+import requests
+
+from . import base
+
+ROMANIA_CPI_SERIES = 'ROUCPIALLMINMEI'
+FRED_CSV_URL = 'https://fred.stlouisfed.org/graph/fredgraph.csv?id={series_id}'
+
+_CREATE_TABLE_SQL = '''
+    CREATE TABLE IF NOT EXISTS ROMANIA_CPI (
+        DATE   TEXT PRIMARY KEY,
+        CPI    REAL NOT NULL,
+        CPI100 REAL NOT NULL
+    )
+'''
+
+
+class InflationFetcher:
+    def __init__(self, db_conn: base.BaseDBConnector):
+        self.db_conn = db_conn
+        self._ensure_table()
+
+    def _ensure_table(self):
+        self.db_conn._conn.execute(_CREATE_TABLE_SQL)
+        self.db_conn._conn.commit()
+
+    def _oldest_transaction_date(self):
+        try:
+            df = self.db_conn.read_query(
+                "SELECT MIN(DATE(DATE)) as FST_DT FROM `TRANSACTION`"
+            )
+            val = df['FST_DT'].iloc[0]
+            return val if val else None
+        except Exception:
+            return None
+
+    def _fetch_romania_cpi(self):
+        url = FRED_CSV_URL.format(series_id=ROMANIA_CPI_SERIES)
+        resp = requests.get(url, timeout=30)
+        resp.raise_for_status()
+
+        df = pd.read_csv(StringIO(resp.text))
+        # Expected columns: DATE, ROUCPIALLMINMEI
+        if 'DATE' not in df.columns or ROMANIA_CPI_SERIES not in df.columns:
+            return pd.DataFrame(columns=['DATE', 'CPI'])
+
+        df = df[['DATE', ROMANIA_CPI_SERIES]].copy()
+        df.rename(columns={ROMANIA_CPI_SERIES: 'CPI'}, inplace=True)
+
+        df['DATE'] = pd.to_datetime(df['DATE'], errors='coerce')
+        df['CPI'] = pd.to_numeric(df['CPI'], errors='coerce')
+        df = df.dropna(subset=['DATE', 'CPI'])
+        df = df.sort_values('DATE').reset_index(drop=True)
+        return df
+
+    def fetch_and_store(self, end_date: Optional[str] = None):
+        base_date = self._oldest_transaction_date()
+        if not base_date:
+            print('No transactions found; skipping Romania CPI fetch')
+            return
+
+        end_ts = pd.to_datetime(end_date or datetime.now().strftime('%Y-%m-%d'))
+        base_ts = pd.to_datetime(base_date)
+
+        df = self._fetch_romania_cpi()
+        if df.empty:
+            print('Romania CPI source returned no data')
+            return
+
+        # Keep data up to requested end date.
+        df = df[df['DATE'] <= end_ts].copy()
+        if df.empty:
+            print('Romania CPI has no observations in requested range')
+            return
+
+        # Anchor CPI100 at the latest available CPI observation on/before oldest transaction date.
+        anchor_rows = df[df['DATE'] <= base_ts]
+        if anchor_rows.empty:
+            anchor_cpi = float(df['CPI'].iloc[0])
+            print('Oldest transaction predates CPI history; anchoring at first CPI observation')
+        else:
+            anchor_cpi = float(anchor_rows['CPI'].iloc[-1])
+
+        if anchor_cpi == 0:
+            print('Anchor CPI is zero; skipping Romania CPI insert')
+            return
+
+        df['CPI100'] = (df['CPI'] / anchor_cpi) * 100.0
+        df['DATE'] = df['DATE'].dt.strftime('%Y-%m-%d')
+
+        # Store only from the first transaction date onward for portfolio relevance.
+        df = df[df['DATE'] >= base_date].copy()
+
+        # Ensure an explicit anchor row at base_date with CPI100=100.
+        if not (df['DATE'] == base_date).any():
+            anchor_row = pd.DataFrame([
+                {'DATE': base_date, 'CPI': anchor_cpi, 'CPI100': 100.0}
+            ])
+            df = pd.concat([anchor_row, df], ignore_index=True)
+
+        df = df.drop_duplicates(subset=['DATE'], keep='last').sort_values('DATE').reset_index(drop=True)
+
+        for _, row in df[['DATE', 'CPI', 'CPI100']].iterrows():
+            self.db_conn._conn.execute(
+                'INSERT OR REPLACE INTO ROMANIA_CPI (DATE, CPI, CPI100) VALUES (?, ?, ?)',
+                (row['DATE'], float(row['CPI']), float(row['CPI100']))
+            )
+        self.db_conn._conn.commit()
+
+        print(f'Stored {len(df)} Romania CPI rows (base date {base_date} = 100)')
+
+    def get_series(self, start_date: str, end_date: str):
+        return self.db_conn.read_query(f'''
+            SELECT DATE, CPI, CPI100
+            FROM ROMANIA_CPI
+            WHERE DATE >= '{start_date}'
+              AND DATE <= '{end_date}'
+            ORDER BY DATE
+        ''')

--- a/server.py
+++ b/server.py
@@ -429,10 +429,39 @@ def benchmark_multi():
     bench_list = request.args.get('benchmarks', 'SPY,QQQ,AGG')
     bench_tickers = [b.strip() for b in bench_list.split(',')]
     start_date = request.args.get('start_date')
-    end_date = request.args.get('end_date')
+    end_date = request.args.get('end_date', utils.date2str(datetime.now()))
     step = int(request.args.get('step', 7))
+    filters = request.args.get('filters')
+    filter_kind = request.args.get('filter_kind')
+    default_interval = request.args.get('default_interval')
+    include_series = request.args.get('include_series', 'false').lower() in ('1', 'true', 'yes')
 
-    pb = benchmarks.PortfolioBenchmark(DB_PATH, start_date, end_date, step)
+    if default_interval:
+        try:
+            delta = get_delta_from_interval(default_interval, end_date)
+            start_date = utils.date2str(utils.str2date(end_date) - delta)
+        except Exception:
+            pass
+
+    pb = benchmarks.PortfolioBenchmark(DB_PATH, start_date, end_date, step, filters, filter_kind)
+
+    if include_series:
+        series = {}
+        comparisons = []
+        for bench in bench_tickers:
+            comp = pb.compare_performance(bench)
+            if 'error' in comp:
+                continue
+            series[bench] = comp
+            comparisons.append({
+                'benchmark': bench,
+                'name': benchmarks.BENCHMARKS.get(bench, bench),
+                'benchmark_return': comp['benchmark_total_return'],
+                'portfolio_return': comp['portfolio_total_return'],
+                'outperformance': comp['outperformance'],
+            })
+        return {'comparisons': comparisons, 'series': series}
+
     return {'comparisons': pb.multi_benchmark_comparison(bench_tickers)}
 
 

--- a/server.py
+++ b/server.py
@@ -141,6 +141,7 @@ def performance():
     try:
         db_conn = base.BaseDBConnector(DB_PATH)
         misc_fetcher_ = misc_fetcher.MiscFetcher(db_conn)
+        inflation_fetcher_ = InflationFetcher(db_conn)
 
         start_dt = request.args.get("start_date", misc_fetcher_.fetch_fst_trans())
         end_dt = request.args.get("end_date", utils.date2str(datetime.now()))
@@ -149,6 +150,7 @@ def performance():
         kind = request.args.get("kind", 'Absolute')
         filters = request.args.get("filters")
         filter_kind = request.args.get("filter_kind")
+        inflation_adjusted = request.args.get('inflation_adjusted', 'false').lower() in ('1', 'true', 'yes')
 
         if filters != 'ALL' and filters is not None and filter_kind is not None:
             ref_portfolio_dt = misc_fetcher_.fetch_fst_trans_on_filter(filters, filter_kind)
@@ -177,6 +179,39 @@ def performance():
             ref_cost = api.PortfolioStats(DB_PATH, filters=filters, filter_kind=filter_kind, ref_date=end_dt).get_cost()
             df_profits['profit'] = df_profits.date.apply(lambda x: api.PortfolioStats(DB_PATH, x, filters=filters, filter_kind=filter_kind,
              ref_profit=ref_profit, ref_cost=ref_cost).get_profit_perc())
+
+        if inflation_adjusted and len(df_profits) > 0:
+            try:
+                inflation_fetcher_.fetch_and_store(end_dt)
+                cpi_df = inflation_fetcher_.get_series(start_dt, end_dt)
+
+                if not cpi_df.empty:
+                    cpi_df['DATE'] = pd.to_datetime(cpi_df['DATE'])
+                    cpi_df = cpi_df[['DATE', 'CPI100']].sort_values('DATE').drop_duplicates(subset=['DATE'])
+
+                    chart_df = pd.DataFrame({'date': pd.to_datetime(df_profits['date'])}).sort_values('date')
+                    cpi_aligned = pd.merge_asof(
+                        chart_df,
+                        cpi_df.rename(columns={'DATE': 'date'}),
+                        on='date',
+                        direction='backward'
+                    )
+
+                    cpi_aligned['CPI100'] = cpi_aligned['CPI100'].ffill().bfill()
+                    start_cpi = cpi_aligned['CPI100'].iloc[0] if len(cpi_aligned) > 0 else None
+
+                    if start_cpi and start_cpi > 0:
+                        inflation_factor = cpi_aligned['CPI100'] / start_cpi
+
+                        if kind == 'Absolute':
+                            df_profits['profit'] = (df_profits['profit'] / inflation_factor.values)
+                        else:
+                            nominal_growth = 1.0 + (df_profits['profit'] / 100.0)
+                            real_growth = nominal_growth / inflation_factor.values
+                            df_profits['profit'] = (real_growth - 1.0) * 100.0
+            except Exception as e:
+                logger.warning(f"Inflation adjustment failed, returning nominal series: {e}")
+
         df_profits['date'] = df_profits['date'].apply(lambda x: utils.date2str(x))
 
         return df_profits.to_dict()

--- a/server.py
+++ b/server.py
@@ -7,6 +7,7 @@ from flask_cors import CORS
 
 import multiprocessing
 from backend import fx_fetcher, misc_fetcher, ticker_fetcher, base, api, benchmarks
+from backend.inflation_fetcher import InflationFetcher
 from backend.benchmark_fetcher import BenchmarkFetcher
 from utils import utils
 
@@ -33,6 +34,7 @@ def fetch_data():
         ticker_fetcher_.fetch_ticker_hist(start_dt, end_dt)
         fx_fetcher_.fetch_missing_fx(start_dt, end_dt)
         BenchmarkFetcher(db_conn).fetch_missing(start_dt, end_dt)
+        InflationFetcher(db_conn).fetch_and_store(end_dt)
         logger.info("Background data fetch completed successfully")
     except Exception as e:
         logger.error(f"Background data fetch failed: {e}")
@@ -575,6 +577,28 @@ def insights():
 def available_benchmarks():
     """List available benchmark indices for comparison."""
     return {'benchmarks': [{'ticker': k, 'name': v} for k, v in benchmarks.BENCHMARKS.items()]}
+
+
+@app.route("/inflation", methods=['GET'])
+def inflation():
+    """Romania CPI series, with CPI100 rebased to oldest portfolio transaction date."""
+    try:
+        db_conn = base.BaseDBConnector(DB_PATH)
+        misc_fetcher_ = misc_fetcher.MiscFetcher(db_conn)
+
+        start_date = request.args.get('start_date', misc_fetcher_.fetch_fst_trans())
+        end_date = request.args.get('end_date', utils.date2str(datetime.now()))
+        refresh = request.args.get('refresh', 'false').lower() in ('1', 'true', 'yes')
+
+        inflation_fetcher = InflationFetcher(db_conn)
+        if refresh:
+            inflation_fetcher.fetch_and_store(end_date)
+        df = inflation_fetcher.get_series(start_date, end_date)
+        df.columns = [c.lower() for c in df.columns]
+        return df.to_dict(orient='list')
+    except Exception as e:
+        logger.error(f"Inflation endpoint error: {e}")
+        return jsonify({"error": str(e)}), 500
 
 
 @app.route("/bet_tracking", methods=['GET'])


### PR DESCRIPTION
## Summary
- enhance GET /benchmark_multi with default_interval support
- add ilters + ilter_kind scoping support for portfolio-side comparison
- add optional include_series=true to return full timeseries payload per benchmark

## New query params
- default_interval: one of existing interval shorthands (1W, 1M, 1Q, 6M, 1Y, YTD, 3Y, 5Y)
- ilters: scope value (e.g. ticker/country/sector)
- ilter_kind: scope dimension
- include_series: when true, include series object with date + return arrays

## Why
This makes the multi-benchmark endpoint suitable for richer UI comparisons without extra API calls.
